### PR TITLE
feature: move all get books logic into one method and clear state bef…

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -10,12 +10,11 @@ class BooksApp extends React.Component {
   }
 
   componentDidMount() {
-    getAll().then((books) => {
-      this.setState({ books })
-    })
+    this.updated()
   }
 
   updated = ()=>{
+    this.setState({books:[]})
     getAll().then((books) => {
       this.setState({ books })
     })


### PR DESCRIPTION
…ore setting again

Seemed cleaner to put all getAll books into one method that I can use for init or update.
I found kept seeing an issue when I would change the first book to a new shelf where it was showing in the new shelf but not removing from the old.  I don't know if this was some kind of localStorage caching issue or something with what I was doing.  I fixed by clearing the book in state before setting again.  Not sure this is the correct approach, but it's working.