### PR TITLE
feature: when book is removed from all shelves should reflect in search results

### DIFF
--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -59,7 +59,7 @@ class Search extends Component {
     updateSearchResults = (searchResults,shelfBooks)=>{
         shelfBooks.forEach((book)=>{
             let resultToUpdate = _.findIndex(searchResults, (result) =>{
-                return result.id === book.id; 
+                return result.id === book.id;
             })
             if(resultToUpdate !== -1){
                 searchResults[resultToUpdate].shelf = book.shelf
@@ -97,6 +97,20 @@ class Search extends Component {
         }
     }
 
+    handleShelfChange = (bookId,shelfName)=>{
+        if(shelfName === 'none'){
+            let bookToUpdate = _.findIndex(this.state.searchResults, (book) =>{
+                return bookId === book.id
+            })
+            if(bookToUpdate !== -1){
+                let updatedSearchResults = this.state.searchResults
+                updatedSearchResults[bookToUpdate].shelf = shelfName
+                this.setState({searchResults: updatedSearchResults})
+            }
+            this.props.updateCurrentBooks()
+        }
+    }
+
     clearBooks = () => {
         this.setState({searchResults:[]})
     }
@@ -111,7 +125,6 @@ class Search extends Component {
 
     render(){
         let query = this.state.query;
-        console.log(this.state.searchResults)
         return (
         <div className="search-books">
             <div className="view-title">
@@ -135,7 +148,7 @@ class Search extends Component {
                     <SearchPossibles terms={this.state.possibles} search={this.searchInputHandler} />
                 )}
                 {this.state.searchResults.length > 0 && (
-                    <BookList books={this.state.searchResults} shelfNames={this.props.shelfNames} updateBooks={this.props.updateCurrentBooks} />
+                    <BookList books={this.state.searchResults} shelfNames={this.props.shelfNames} updateBooks={this.handleShelfChange} />
 
                 )}
             </div>

--- a/src/containers/ShelfChanger.js
+++ b/src/containers/ShelfChanger.js
@@ -22,9 +22,11 @@ class ShelfChanger extends Component {
     }
 
     shelfChangeHandler = (event) =>{
-        BooksAPI.update({'id':this.props.bookId},event.target.value)
+        let shelfValue = event.target.value
+        BooksAPI.update({'id':this.props.bookId},shelfValue)
             .then(()=>{
-                this.props.updateBooks()
+                this.setState({defaultSelection:shelfValue})
+                this.props.updateBooks(this.props.bookId,shelfValue)
             })
             .catch((err)=>{
                 console.log(`API ERROR: ${err}`)
@@ -38,7 +40,7 @@ class ShelfChanger extends Component {
         return (
             <div className={shelfChangerClass}>
                 <select value={this.state.defaultSelection} onChange={this.shelfChangeHandler} >
-                    <option value="none" disabled>Move to...</option>
+                    <option disabled>Move to...</option>
                     {shelfNames.map((shelf,index) =>(
                     <option key={index} value={shelf}>{BookUtils.shelfNameConverter(shelf)}</option>
                     ))}


### PR DESCRIPTION
Removal was not happening when invoked from within search results. This was how search results were being updated using the list of current books in the shelf meant that the book that was already removed was not in this list so it was not getting updated in the results.